### PR TITLE
Add feature to star / unstar contacts (favourites list)

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -109,6 +109,15 @@ Format: `list`
 
 * You will be informed when the list is empty: `The list is currently empty.` or when it is not empty: `Listed all persons`.
 
+### Listing starred persons : `list *`
+
+Shows a list of all starred persons in the address book.
+
+Format: `list *`
+
+* No other parameters should be supplied aside from `*`.
+* You will be informed when the list is empty: `No contacts starred` or when it is not empty: `Starred contacts listed`.
+
 ### Editing a person : `edit`
 
 Edits an existing person in the address book.
@@ -163,6 +172,40 @@ Examples:
 * `list` followed by `delete Alex Yeoh` deletes the person with name `Alex Yeoh` in the address book.
 * `list` followed by `delete 2` deletes the 2nd person in the address book.
 * `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
+
+### Starring a person : `star`
+
+Stars the specified person from the address book into favourites.
+
+Format: `star INDEX` / `star NAME`
+
+* Stars the person at the specified `INDEX` or with the specified `NAME`.
+* The name refers to the full name as shown in the displayed person list.
+* The index refers to the index number shown in the displayed person list.
+* The index **must be a positive integer** 1, 2, 3, …​
+
+Examples:
+
+* `star Alex Yeoh` stars the person with name `Alex Yeoh` in the address book.
+* `list` followed by `star 2` stars the 2nd person in the address book.
+* `find Betsy` followed by `star 1` stars the 1st person in the results of the `find` command.
+
+### Unstarring a person : `unstar`
+
+Unstars the specified person from the address book removing them from favourites.
+
+Format: `unstar INDEX` / `unstar NAME`
+
+* Unstars the person at the specified `INDEX` or with the specified `NAME`.
+* The name refers to the full name as shown in the displayed person list.
+* The index refers to the index number shown in the displayed person list.
+* The index **must be a positive integer** 1, 2, 3, …​
+
+Examples:
+
+* `unstar Alex Yeoh` unstars the person with name `Alex Yeoh` in the address book.
+* `list` followed by `unstar 2` unstars the 2nd person in the address book.
+* `find Betsy` followed by `unstar 1` unstars the 1st person in the results of the `find` command.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -128,7 +128,7 @@ public class EditCommand extends Command {
         }
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
-                          updatedAge, updatedSex, updatedAppointment, updatedTags);
+                          updatedAge, updatedSex, updatedAppointment, updatedTags, personToEdit.getStarredStatus());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -25,6 +25,7 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
     public static final String MESSAGE_EMPTY_LIST = "The list is currently empty.";
+    public static final String MESSAGE_EMPTY_STARRED_LIST = "No contacts starred";
     public static final String MESSAGE_STARRED_LIST = "Starred contacts listed";
     public final PersonIsStarredPredicate predicate;
 
@@ -54,6 +55,10 @@ public class ListCommand extends Command {
             }
         } else {
             model.updateFilteredPersonList(predicate);
+            List<Person> lastShownList = model.getFilteredPersonList();
+            if (lastShownList.isEmpty()) {
+                return new CommandResult(MESSAGE_EMPTY_STARRED_LIST);
+            }
             return new CommandResult(MESSAGE_STARRED_LIST);
         }
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -5,9 +5,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
-import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonIsStarredPredicate;
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -5,8 +5,11 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonIsStarredPredicate;
 
 /**
  * Lists all persons in the address book to the user.
@@ -15,17 +18,45 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists relevant contacts\n"
+            + "Parameters: [*] (to list starred contacts)\n"
+            + "Example: " + COMMAND_WORD
+            + "Example: " + COMMAND_WORD + " *";
+
     public static final String MESSAGE_SUCCESS = "Listed all persons";
     public static final String MESSAGE_EMPTY_LIST = "The list is currently empty.";
+    public static final String MESSAGE_STARRED_LIST = "Starred contacts listed";
+    public final PersonIsStarredPredicate predicate;
+
+    /**
+     * Lists all contacts as per usual.
+     */
+    public ListCommand() {
+        this.predicate = null;
+    }
+
+    /**
+     * Lists all starred contacts.
+     */
+    public ListCommand(PersonIsStarredPredicate predicate) {
+        this.predicate = predicate;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        List<Person> lastShownList = model.getFilteredPersonList();
-        if (lastShownList.isEmpty()) {
-            return new CommandResult(MESSAGE_EMPTY_LIST);
+
+        if (predicate == null) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            List<Person> lastShownList = model.getFilteredPersonList();
+            if (lastShownList.isEmpty()) {
+                return new CommandResult(MESSAGE_EMPTY_LIST);
+            }
+        } else {
+            model.updateFilteredPersonList(predicate);
+            return new CommandResult(MESSAGE_STARRED_LIST);
         }
+
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/StarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StarCommand.java
@@ -1,5 +1,13 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -14,14 +22,9 @@ import seedu.address.model.person.Sex;
 import seedu.address.model.person.StarredStatus;
 import seedu.address.model.tag.Tag;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-
+/**
+ * Stars contact to add it into favourites list.
+ */
 public class StarCommand extends Command {
     public static final String COMMAND_WORD = "star";
 

--- a/src/main/java/seedu/address/logic/commands/StarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StarCommand.java
@@ -1,0 +1,109 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StarredStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class StarCommand extends Command {
+    public static final String COMMAND_WORD = "star";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Stars the person identified by the name or index in the address book.\n"
+            + "Parameters: NAME or INDEX (must match exactly one person or be a valid index)\n"
+            + "Example: " + COMMAND_WORD + " John Doe\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_STAR_PERSON_SUCCESS = "Starred Person: %1$s";
+    public static final String MESSAGE_UNSTAR_PERSON_SUCCESS = "Unstarred Person: %1$s";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "The person's name provided is invalid";
+    public static final String MESSAGE_INVALID_INDEX = "The person index provided is invalid";
+
+    private final Name targetName;
+    private final Index targetIndex;
+    private final StarredStatus toStar;
+
+    /**
+     * @param targetName of the person to be starred or unstarred in the list
+     */
+    public StarCommand(Name targetName, StarredStatus toStar) {
+        this.targetName = targetName;
+        this.targetIndex = null;
+        this.toStar = toStar;
+    }
+
+    /**
+     * @param targetIndex of the index of the person to be starred or unstarred in the list
+     */
+    public StarCommand(Index targetIndex, StarredStatus toStar) {
+        this.targetIndex = targetIndex;
+        this.targetName = null;
+        this.toStar = toStar;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        Person personToStar;
+
+        if (targetName != null) {
+            Optional<Person> personOptional = lastShownList.stream()
+                    .filter(person -> person.getName().equals(targetName))
+                    .findFirst();
+
+            if (personOptional.isEmpty()) {
+                throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
+            }
+            personToStar = personOptional.get();
+        } else {
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(MESSAGE_INVALID_INDEX);
+            }
+            personToStar = lastShownList.get(targetIndex.getZeroBased());
+        }
+
+        model.deletePerson(personToStar);
+
+        String result = toStar.value.equals("true")
+                ? String.format(MESSAGE_STAR_PERSON_SUCCESS, personToStar.getName())
+                : String.format(MESSAGE_UNSTAR_PERSON_SUCCESS, personToStar.getName());
+
+        return new CommandResult(result);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof StarCommand)) {
+            return false;
+        }
+
+        StarCommand otherStarCommand = (StarCommand) other;
+
+
+        return (targetName != null && targetName.equals(otherStarCommand.targetName))
+                || (targetIndex != null && targetIndex.equals(otherStarCommand.targetIndex))
+                && toStar.equals(otherStarCommand.toStar);
+    }
+
+    @Override
+    public String toString() {
+        if (targetName != null) {
+            return String.format("StarCommand[targetName=%s, toStar=%s]", targetName, toStar);
+        } else {
+            return String.format("StarCommand[targetIndex=%d, toStar=%s]", targetIndex.getOneBased(), toStar);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/StarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StarCommand.java
@@ -78,8 +78,8 @@ public class StarCommand extends Command {
             personToStar = lastShownList.get(targetIndex.getZeroBased());
         }
 
-        if (personToStar.getStarredStatus().equals("true")) {
-            throw new CommandException(MESSAGE_ALREADY_STARRED);
+        if (personToStar.getStarredStatus().equals(new StarredStatus("true"))) {
+            throw new CommandException(String.format(MESSAGE_ALREADY_STARRED, personToStar.getName()));
         } else {
             Person editedPerson = createEditedPerson(personToStar);
             model.setPerson(personToStar, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/UnstarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnstarCommand.java
@@ -1,0 +1,138 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Age;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Sex;
+import seedu.address.model.person.StarredStatus;
+import seedu.address.model.tag.Tag;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+public class UnstarCommand extends Command {
+    public static final String COMMAND_WORD = "unstar";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unstars the person identified by the name or index in the address book.\n"
+            + "Parameters: NAME or INDEX (must match exactly one person or be a valid index)\n"
+            + "Example: " + COMMAND_WORD + " John Doe\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_UNSTAR_PERSON_SUCCESS = "Unstarred Person: %1$s";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "The person's name provided is invalid";
+    public static final String MESSAGE_INVALID_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_ALREADY_UNSTARRED = "%1$s is not starred";
+
+    private final Name targetName;
+    private final Index targetIndex;
+
+    /**
+     * @param targetName of the person to be unstarred in the list
+     */
+    public UnstarCommand(Name targetName) {
+        this.targetName = targetName;
+        this.targetIndex = null;
+    }
+
+    /**
+     * @param targetIndex of the index of the person to be unstarred in the list
+     */
+    public UnstarCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+        this.targetName = null;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        Person personToUnstar;
+
+        if (targetName != null) {
+            Optional<Person> personOptional = lastShownList.stream()
+                    .filter(person -> person.getName().equals(targetName))
+                    .findFirst();
+
+            if (personOptional.isEmpty()) {
+                throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
+            }
+            personToUnstar = personOptional.get();
+        } else {
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(MESSAGE_INVALID_INDEX);
+            }
+            personToUnstar = lastShownList.get(targetIndex.getZeroBased());
+        }
+
+        if (personToUnstar.getStarredStatus().equals(new StarredStatus("false"))) {
+            throw new CommandException(String.format(MESSAGE_ALREADY_UNSTARRED, personToUnstar.getName()));
+        } else {
+            Person editedPerson = createEditedPerson(personToUnstar);
+            model.setPerson(personToUnstar, editedPerson);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        }
+
+        return new CommandResult(String.format(MESSAGE_UNSTAR_PERSON_SUCCESS, personToUnstar.getName()));
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the same details but starredStatus as true.
+     * edited with {@code editPersonDescriptor}.
+     */
+    private static Person createEditedPerson(Person personToEdit) {
+        assert personToEdit != null;
+
+        Name name = personToEdit.getName();
+        Phone phone = personToEdit.getPhone();
+        Email email = personToEdit.getEmail();
+        Address address = personToEdit.getAddress();
+        Age age = personToEdit.getAge();
+        Sex sex = personToEdit.getSex();
+        Set<Appointment> appointment = new HashSet<>(personToEdit.getAppointment());
+        Set<Tag> tags = new HashSet<>(personToEdit.getTags());
+        StarredStatus starredStatus = new StarredStatus("false");
+
+        return new Person(name, phone, email, address,
+                age, sex, appointment, tags, starredStatus);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof UnstarCommand)) {
+            return false;
+        }
+
+        UnstarCommand otherUnstarCommand = (UnstarCommand) other;
+
+
+        return (targetName != null && targetName.equals(otherUnstarCommand.targetName))
+                || (targetIndex != null && targetIndex.equals(otherUnstarCommand.targetIndex));
+    }
+
+    @Override
+    public String toString() {
+        if (targetName != null) {
+            return String.format("UnstarCommand[targetName=%s]", targetName);
+        } else {
+            return String.format("UnstarCommand[targetIndex=%d]", targetIndex.getOneBased());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnstarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnstarCommand.java
@@ -1,5 +1,13 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -14,14 +22,9 @@ import seedu.address.model.person.Sex;
 import seedu.address.model.person.StarredStatus;
 import seedu.address.model.tag.Tag;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-
+/**
+ * Unstars contacts that have been starred to remove it from favourites list.
+ */
 public class UnstarCommand extends Command {
     public static final String COMMAND_WORD = "unstar";
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -23,6 +23,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Sex;
+import seedu.address.model.person.StarredStatus;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -56,8 +57,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         Sex sex = ParserUtil.parseSex(argMultimap.getValue(PREFIX_SEX).get());
         Set<Appointment> appointment = ParserUtil.parseAppointments(argMultimap.getAllValues(PREFIX_APPOINTMENT));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        StarredStatus starredStatus = new StarredStatus("false");
 
-        Person person = new Person(name, phone, email, address, age, sex, appointment, tagList);
+        Person person = new Person(name, phone, email, address, age, sex, appointment, tagList, starredStatus);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -71,7 +71,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.StarCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case StarCommand.COMMAND_WORD:
+            return new StarCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.StarCommand;
+import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,9 @@ public class AddressBookParser {
 
         case StarCommand.COMMAND_WORD:
             return new StarCommandParser().parse(arguments);
+
+        case UnstarCommand.COMMAND_WORD:
+            return new UnstarCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PersonIsStarredPredicate;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListCommand
+     * and returns a ListCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            return new ListCommand();
+        } else if (trimmedArgs.equals("*")) {
+            return new ListCommand(new PersonIsStarredPredicate());
+        } else {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        }
+
+    }
+
+}
+

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -2,11 +2,8 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.Arrays;
-
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.PersonIsStarredPredicate;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/StarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StarCommandParser.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.StarCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object.
+ */
+public class StarCommandParser implements Parser<StarCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the StarCommand
+     * and returns a StarCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public StarCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, StarCommand.MESSAGE_USAGE));
+        }
+
+
+        try {
+            Index index = ParserUtil.parseIndex(trimmedArgs);
+            return new StarCommand(index);
+        } catch (ParseException pe) {
+
+            try {
+                Name name = ParserUtil.parseName(trimmedArgs);
+                return new StarCommand(name);
+            } catch (ParseException pe2) {
+
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, StarCommand.MESSAGE_USAGE), pe2);
+            }
+        }
+    }
+}
+

--- a/src/main/java/seedu/address/logic/parser/StarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StarCommandParser.java
@@ -8,7 +8,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 
 /**
- * Parses input arguments and creates a new DeleteCommand object.
+ * Parses input arguments and creates a new StarCommand object.
  */
 public class StarCommandParser implements Parser<StarCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnstarCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object.
+ */
+public class UnstarCommandParser implements Parser<UnstarCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnstarCommand
+     * and returns a UnstarCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public UnstarCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnstarCommand.MESSAGE_USAGE));
+        }
+
+
+        try {
+            Index index = ParserUtil.parseIndex(trimmedArgs);
+            return new UnstarCommand(index);
+        } catch (ParseException pe) {
+
+            try {
+                Name name = ParserUtil.parseName(trimmedArgs);
+                return new UnstarCommand(name);
+            } catch (ParseException pe2) {
+
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnstarCommand.MESSAGE_USAGE), pe2);
+            }
+        }
+    }
+}
+
+

--- a/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
@@ -8,7 +8,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 
 /**
- * Parses input arguments and creates a new DeleteCommand object.
+ * Parses input arguments and creates a new UnstarCommand object.
  */
 public class UnstarCommandParser implements Parser<UnstarCommand> {
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -28,13 +28,14 @@ public class Person {
     private final Sex sex;
     private final Set<Appointment> appointments = new HashSet<>();
     private final Set<Tag> tags = new HashSet<>();
+    private final StarredStatus starredStatus;
 
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address,
-                  Age age, Sex sex, Set<Appointment> appointments, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, age, sex, appointments, tags);
+                  Age age, Sex sex, Set<Appointment> appointments, Set<Tag> tags, StarredStatus starredStatus) {
+        requireAllNonNull(name, phone, email, address, age, sex, appointments, tags, starredStatus);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -43,6 +44,7 @@ public class Person {
         this.sex = sex;
         this.appointments.addAll(appointments);
         this.tags.addAll(tags);
+        this.starredStatus = starredStatus;
     }
 
     public Name getName() {
@@ -83,6 +85,9 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+    public StarredStatus getStarredStatus() {
+        return starredStatus;
     }
 
     /**
@@ -127,7 +132,7 @@ public class Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, age, sex, tags, appointments);
+        return Objects.hash(name, phone, email, address, age, sex, tags, appointments, starredStatus);
 
     }
 
@@ -142,6 +147,7 @@ public class Person {
                 .add("sex", sex)
                 .add("appointments", appointments)
                 .add("tags", tags)
+                .add("starred", starredStatus)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -147,7 +147,7 @@ public class Person {
                 .add("sex", sex)
                 .add("appointments", appointments)
                 .add("tags", tags)
-                .add("starred", starredStatus)
+                .add("starredStatus", starredStatus)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/person/PersonIsStarredPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonIsStarredPredicate.java
@@ -1,9 +1,7 @@
 package seedu.address.model.person;
 
-import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**

--- a/src/main/java/seedu/address/model/person/PersonIsStarredPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonIsStarredPredicate.java
@@ -1,0 +1,37 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code StarredStatus} is true.
+ */
+public class PersonIsStarredPredicate implements Predicate<Person> {
+
+    @Override
+    public boolean test(Person person) {
+        return person.getStarredStatus().equals(new StarredStatus("true"));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PersonIsStarredPredicate)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/StarredStatus.java
+++ b/src/main/java/seedu/address/model/person/StarredStatus.java
@@ -1,0 +1,59 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class StarredStatus {
+    public static final String MESSAGE_CONSTRAINTS = "Starred status should be true or false, " +
+            "and it should not be blank";
+
+    /*
+     * StarredStatus should only be true or false.
+     */
+    public static final String VALIDATION_REGEX = "^(true|false)$";
+
+    public final String value;
+
+    /**
+     * Constructs an {@code StarrredStatus}.
+     *
+     * @param isStarred A valid star status.
+     */
+    public StarredStatus(String isStarred) {
+        requireNonNull(isStarred);
+        checkArgument(isValidStarredStatus(isStarred), MESSAGE_CONSTRAINTS);
+        value = isStarred;
+    }
+
+    /**
+     * Returns true if a given string is a valid status.
+     */
+    public static boolean isValidStarredStatus(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof StarredStatus)) {
+            return false;
+        }
+
+        StarredStatus otherStarredStatus = (StarredStatus) other;
+        return value.equals(otherStarredStatus.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/StarredStatus.java
+++ b/src/main/java/seedu/address/model/person/StarredStatus.java
@@ -3,9 +3,12 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+/**
+ * Represents whether a contact has been starred (true) or not (false).
+ */
 public class StarredStatus {
-    public static final String MESSAGE_CONSTRAINTS = "Starred status should be true or false, " +
-            "and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Starred status should be true or false, "
+            + "and it should not be blank";
 
     /*
      * StarredStatus should only be true or false.

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Sex;
+import seedu.address.model.person.StarredStatus;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -24,22 +25,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Age("23"), new Sex("Male"),
-                getAppointmentSet("11/11/2025 1100"), getTagSet("friends")),
+                getAppointmentSet("11/11/2025 1100"), getTagSet("friends"), new StarredStatus("false")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Age("54"), new Sex("Female"),
-                getAppointmentSet("07/01/2026 0800"), getTagSet("colleagues", "friends")),
+                getAppointmentSet("07/01/2026 0800"), getTagSet("colleagues", "friends"), new StarredStatus("false")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Age("100"), new Sex("Female"),
-                getAppointmentSet("22/07/2024 1300"), getTagSet("neighbours")),
+                getAppointmentSet("22/07/2024 1300"), getTagSet("neighbours"), new StarredStatus("false")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Age("27"), new Sex("Male"),
-                getAppointmentSet("11/11/2025 1100"), getTagSet("family")),
+                getAppointmentSet("11/11/2025 1100"), getTagSet("family"), new StarredStatus("false")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Age("103"), new Sex("Male"),
-                getAppointmentSet("11/11/2025 1100"), getTagSet("classmates")),
+                getAppointmentSet("11/11/2025 1100"), getTagSet("classmates"), new StarredStatus("false")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Age("87"), new Sex("Male"),
-                getAppointmentSet("11/11/2025 1100"), getTagSet("colleagues"))
+                getAppointmentSet("11/11/2025 1100"), getTagSet("colleagues"), new StarredStatus("false"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Sex;
+import seedu.address.model.person.StarredStatus;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -35,6 +36,7 @@ class JsonAdaptedPerson {
     private final String sex;
     private final List<JsonAdaptedAppointment> appointments = new ArrayList<>();
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    private final String starredStatus;
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -44,7 +46,7 @@ class JsonAdaptedPerson {
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("age") String age, @JsonProperty("sex") String sex,
             @JsonProperty("appointments") List<JsonAdaptedAppointment> appointments,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+            @JsonProperty("tags") List<JsonAdaptedTag> tags, @JsonProperty("starred") String starredStatus) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -57,6 +59,7 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
+        this.starredStatus = starredStatus;
     }
 
     /**
@@ -75,6 +78,7 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        starredStatus = source.getStarredStatus().value;
     }
 
     /**
@@ -145,7 +149,16 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
+        if (starredStatus == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    StarredStatus.class.getSimpleName()));
+        }
+        if (!StarredStatus.isValidStarredStatus(starredStatus)) {
+            throw new IllegalValueException(StarredStatus.MESSAGE_CONSTRAINTS);
+        }
+        final StarredStatus modelStarredStatus = new StarredStatus(starredStatus);
+
         return new Person(modelName, modelPhone, modelEmail, modelAddress,
-                modelAge, modelSex, modelAppointment, modelTags);
+                modelAge, modelSex, modelAppointment, modelTags, modelStarredStatus);
     }
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -3,11 +3,18 @@
     "name": "Valid Person",
     "phone": "9482424",
     "email": "hans@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "sex" : "Female",
+    "tags" : [ ],
+    "starredStatus" : "false"
+
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "hans@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "sex" : "Female",
+    "tags" : [ ],
+    "starredStatus" : "false"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -6,13 +6,15 @@
     "address": "123, Jurong West Ave 6, #08-111",
     "age" : "24",
     "sex" : "Female",
-    "tags": [ "friends" ]
+    "tags": [ "friends" ],
+    "starredStatus" : "false"
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street",
     "age" : "24",
-    "sex" : "Female"
+    "sex" : "Female",
+    "starredStatus" : "false"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -7,7 +7,8 @@
     "address" : "123, Jurong West Ave 6, #08-111",
     "age" : "24",
     "sex" : "Female",
-    "tags" : [ "friends" ]
+    "tags" : [ "friends" ],
+    "starredStatus" : "false"
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
@@ -15,7 +16,8 @@
     "address" : "311, Clementi Ave 2, #02-25",
     "age" : "37",
     "sex" : "Male",
-    "tags" : [ "owesMoney", "friends" ]
+    "tags" : [ "owesMoney", "friends" ],
+    "starredStatus" : "false"
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
@@ -23,7 +25,8 @@
     "address" : "wall street",
     "age" : "29",
     "sex" : "Female",
-    "tags" : [ ]
+    "tags" : [ ],
+    "starredStatus" : "false"
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
@@ -31,7 +34,8 @@
     "address" : "10th street",
     "age" : "40",
     "sex" : "Male",
-    "tags" : [ "friends" ]
+    "tags" : [ "friends" ],
+    "starredStatus" : "false"
   }, {
     "name" : "Elle Meyer",
     "phone" : "94822245",
@@ -39,7 +43,8 @@
     "address" : "michegan ave",
     "age" : "16",
     "sex" : "Female",
-    "tags" : [ ]
+    "tags" : [ ],
+    "starredStatus" : "false"
   }, {
     "name" : "Fiona Kunz",
     "phone" : "94824275",
@@ -47,7 +52,8 @@
     "address" : "little tokyo",
     "age" : "70",
     "sex" : "Female",
-    "tags" : [ ]
+    "tags" : [ ],
+    "starredStatus" : "false"
   }, {
     "name" : "George Best",
     "phone" : "94824425",
@@ -55,6 +61,7 @@
     "address" : "4th street",
     "age" : "88",
     "sex" : "Male",
-    "tags" : [ ]
+    "tags" : [ ],
+    "starredStatus" : "false"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -17,7 +17,7 @@
     "age" : "37",
     "sex" : "Male",
     "tags" : [ "owesMoney", "friends" ],
-    "starredStatus" : "false"
+    "starredStatus" : "true"
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -12,7 +12,9 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonIsStarredPredicate;
+import seedu.address.model.person.StarredStatus;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -49,6 +51,20 @@ public class ListCommandTest {
     }
     @Test
     public void execute_listStarredContacts_showsStarredList() {
+        Person personToStar = model.getFilteredPersonList().get(0);
+        Person alreadyStarredPerson = new Person(
+                personToStar.getName(),
+                personToStar.getPhone(),
+                personToStar.getEmail(),
+                personToStar.getAddress(),
+                personToStar.getAge(),
+                personToStar.getSex(),
+                personToStar.getAppointment(),
+                personToStar.getTags(),
+                new StarredStatus("true"));
+        model.setPerson(personToStar, alreadyStarredPerson);
+        expectedModel.setPerson(personToStar, alreadyStarredPerson);
+
         PersonIsStarredPredicate predicate = new PersonIsStarredPredicate();
         ListCommand listStarredCommand = new ListCommand(predicate);
 
@@ -66,6 +82,6 @@ public class ListCommandTest {
         PersonIsStarredPredicate predicate = new PersonIsStarredPredicate();
         ListCommand listStarredCommand = new ListCommand(predicate);
 
-        assertCommandSuccess(listStarredCommand, noStarredModel, ListCommand.MESSAGE_STARRED_LIST, expectedNoStarredModel);
+        assertCommandSuccess(listStarredCommand, noStarredModel, ListCommand.MESSAGE_EMPTY_STARRED_LIST, expectedNoStarredModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -82,6 +82,7 @@ public class ListCommandTest {
         PersonIsStarredPredicate predicate = new PersonIsStarredPredicate();
         ListCommand listStarredCommand = new ListCommand(predicate);
 
-        assertCommandSuccess(listStarredCommand, noStarredModel, ListCommand.MESSAGE_EMPTY_STARRED_LIST, expectedNoStarredModel);
+        assertCommandSuccess(listStarredCommand, noStarredModel, ListCommand.MESSAGE_EMPTY_STARRED_LIST,
+                expectedNoStarredModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -12,6 +12,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PersonIsStarredPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -45,5 +46,26 @@ public class ListCommandTest {
 
         // Check that the command shows the empty list message
         assertCommandSuccess(new ListCommand(), emptyModel, ListCommand.MESSAGE_EMPTY_LIST, expectedEmptyModel);
+    }
+    @Test
+    public void execute_listStarredContacts_showsStarredList() {
+        PersonIsStarredPredicate predicate = new PersonIsStarredPredicate();
+        ListCommand listStarredCommand = new ListCommand(predicate);
+
+        model.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+
+        assertCommandSuccess(listStarredCommand, model, ListCommand.MESSAGE_STARRED_LIST, expectedModel);
+    }
+
+    @Test
+    public void execute_listNoStarredContacts_showsStarredList() {
+        Model noStarredModel = new ModelManager(new AddressBook(), new UserPrefs());
+        Model expectedNoStarredModel = new ModelManager(new AddressBook(), new UserPrefs());
+
+        PersonIsStarredPredicate predicate = new PersonIsStarredPredicate();
+        ListCommand listStarredCommand = new ListCommand(predicate);
+
+        assertCommandSuccess(listStarredCommand, noStarredModel, ListCommand.MESSAGE_STARRED_LIST, expectedNoStarredModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/StarCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StarCommandTest.java
@@ -1,0 +1,154 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StarredStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for StarCommand.
+ */
+public class StarCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndex_success() throws Exception {
+        Person personToStar = model.getFilteredPersonList().get(Index.fromZeroBased(0).getZeroBased());
+        StarCommand starCommand = new StarCommand(Index.fromZeroBased(0));
+
+        CommandResult commandResult = starCommand.execute(model);
+
+        assertEquals(String.format(StarCommand.MESSAGE_STAR_PERSON_SUCCESS, personToStar.getName()),
+                commandResult.getFeedbackToUser());
+
+        Person starredPerson = model.getFilteredPersonList().get(Index.fromZeroBased(0).getZeroBased());
+        assertEquals(new StarredStatus("true"), starredPerson.getStarredStatus());
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Index invalidIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        StarCommand starCommand = new StarCommand(invalidIndex);
+
+        assertCommandFailure(starCommand, model, StarCommand.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void execute_validNameFilteredList_success() throws CommandException {
+        Person personToStar = model.getFilteredPersonList().get(0);
+        Name targetName = personToStar.getName();
+        StarCommand starCommand = new StarCommand(targetName);
+
+        CommandResult commandResult = starCommand.execute(model);
+
+        assertEquals(String.format(StarCommand.MESSAGE_STAR_PERSON_SUCCESS, personToStar.getName()),
+                commandResult.getFeedbackToUser());
+
+        Person starredPerson = model.getFilteredPersonList().stream()
+                .filter(person -> person.getName().equals(targetName))
+                .findFirst().orElse(null);
+
+        assertEquals(new StarredStatus("true"), starredPerson.getStarredStatus());
+    }
+
+    @Test
+    public void execute_invalidNameFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Name invalidName = new Name("Nonexistent Name");
+        StarCommand starCommand = new StarCommand(invalidName);
+
+        assertCommandFailure(starCommand, model, String.format(StarCommand.MESSAGE_PERSON_NOT_FOUND, invalidName));
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        StarCommand starCommand = new StarCommand(outOfBoundIndex);
+        assertCommandFailure(starCommand, model, StarCommand.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void execute_negativeIndex_throwsIndexOutOfBoundsException() {
+        int negativeIndexValue = -1;
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            Index negativeIndex = Index.fromOneBased(negativeIndexValue);
+            new StarCommand(negativeIndex);
+        });
+    }
+
+    @Test
+    public void equals() {
+        StarCommand starNameCommand = new StarCommand(new Name("Alice"));
+        StarCommand starNameCommandCopy = new StarCommand(new Name("Alice"));
+        StarCommand starIndexCommand = new StarCommand(Index.fromOneBased(1));
+
+        // same object -> returns true
+        assertTrue(starNameCommand.equals(starNameCommand));
+
+        // same values -> returns true
+        assertTrue(starNameCommand.equals(starNameCommandCopy));
+
+        // different types -> returns false
+        assertFalse(starNameCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(starNameCommand.equals(null));
+
+        // different names -> returns false
+        assertFalse(starNameCommand.equals(starIndexCommand));
+
+        // different index -> returns false
+        assertFalse(starIndexCommand.equals(starNameCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        // Testing with name
+        Name targetName = new Name("John Doe");
+        StarCommand starCommandByName = new StarCommand(targetName);
+        String expectedNameString = String.format("StarCommand[targetName=%s]", targetName);
+        assertEquals(expectedNameString, starCommandByName.toString());
+
+        // Testing with index
+        Index targetIndex = Index.fromOneBased(1);
+        StarCommand starCommandByIndex = new StarCommand(targetIndex);
+        String expectedIndexString = String.format("StarCommand[targetIndex=%d]", targetIndex.getOneBased());
+        assertEquals(expectedIndexString, starCommandByIndex.toString());
+    }
+
+    @Test
+    public void execute_personAlreadyStarred_throwsCommandException() {
+        Person personToStar = model.getFilteredPersonList().get(0);
+        Person alreadyStarredPerson = new Person(
+                personToStar.getName(),
+                personToStar.getPhone(),
+                personToStar.getEmail(),
+                personToStar.getAddress(),
+                personToStar.getAge(),
+                personToStar.getSex(),
+                personToStar.getAppointment(),
+                personToStar.getTags(),
+                new StarredStatus("true"));
+        model.setPerson(personToStar, alreadyStarredPerson);
+
+        StarCommand starCommand = new StarCommand(alreadyStarredPerson.getName());
+
+        assertCommandFailure(starCommand, model,
+                String.format(StarCommand.MESSAGE_ALREADY_STARRED, alreadyStarredPerson.getName()));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/StarCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StarCommandTest.java
@@ -1,15 +1,5 @@
 package seedu.address.logic.commands;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.StarredStatus;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,6 +8,17 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StarredStatus;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for StarCommand.

--- a/src/test/java/seedu/address/logic/commands/UnstarCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnstarCommandTest.java
@@ -1,0 +1,174 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StarredStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for UnstarCommand.
+ */
+public class UnstarCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndex_success() throws Exception {
+        Person personToUnstar = model.getFilteredPersonList().get(Index.fromZeroBased(0).getZeroBased());
+        Person starredPerson = new Person(
+                personToUnstar.getName(),
+                personToUnstar.getPhone(),
+                personToUnstar.getEmail(),
+                personToUnstar.getAddress(),
+                personToUnstar.getAge(),
+                personToUnstar.getSex(),
+                personToUnstar.getAppointment(),
+                personToUnstar.getTags(),
+                new StarredStatus("true"));
+
+        model.setPerson(personToUnstar, starredPerson);
+
+        UnstarCommand unstarCommand = new UnstarCommand(Index.fromZeroBased(0));
+
+        CommandResult commandResult = unstarCommand.execute(model);
+
+        assertEquals(String.format(UnstarCommand.MESSAGE_UNSTAR_PERSON_SUCCESS, starredPerson.getName()),
+                commandResult.getFeedbackToUser());
+
+        Person unstarredPerson = model.getFilteredPersonList().get(Index.fromZeroBased(0).getZeroBased());
+        assertEquals(new StarredStatus("false"), unstarredPerson.getStarredStatus());
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Index invalidIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        UnstarCommand unstarCommand = new UnstarCommand(invalidIndex);
+
+        assertCommandFailure(unstarCommand, model, StarCommand.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void execute_validNameFilteredList_success() throws CommandException {
+        Person personToUnstar = model.getFilteredPersonList().get(0);
+        Person starredPerson = new Person(
+                personToUnstar.getName(),
+                personToUnstar.getPhone(),
+                personToUnstar.getEmail(),
+                personToUnstar.getAddress(),
+                personToUnstar.getAge(),
+                personToUnstar.getSex(),
+                personToUnstar.getAppointment(),
+                personToUnstar.getTags(),
+                new StarredStatus("true"));
+
+        model.setPerson(personToUnstar, starredPerson);
+
+        Name targetName = personToUnstar.getName();
+        UnstarCommand unstarCommand = new UnstarCommand(targetName);
+
+        CommandResult commandResult = unstarCommand.execute(model);
+
+        assertEquals(String.format(UnstarCommand.MESSAGE_UNSTAR_PERSON_SUCCESS, starredPerson.getName()),
+                commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_invalidNameFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Name invalidName = new Name("Nonexistent Name");
+        UnstarCommand unstarCommand = new UnstarCommand(invalidName);
+
+        assertCommandFailure(unstarCommand, model, String.format(UnstarCommand.MESSAGE_PERSON_NOT_FOUND, invalidName));
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        UnstarCommand unstarCommand = new UnstarCommand(outOfBoundIndex);
+        assertCommandFailure(unstarCommand, model, UnstarCommand.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void execute_negativeIndex_throwsIndexOutOfBoundsException() {
+        int negativeIndexValue = -1;
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            Index negativeIndex = Index.fromOneBased(negativeIndexValue);
+            new UnstarCommand(negativeIndex);
+        });
+    }
+
+    @Test
+    public void equals() {
+        UnstarCommand unstarNameCommand = new UnstarCommand(new Name("Alice"));
+        UnstarCommand unstarNameCommandCopy = new UnstarCommand(new Name("Alice"));
+        UnstarCommand unstarIndexCommand = new UnstarCommand(Index.fromOneBased(1));
+
+        // same object -> returns true
+        assertTrue(unstarNameCommand.equals(unstarNameCommand));
+
+        // same values -> returns true
+        assertTrue(unstarNameCommand.equals(unstarNameCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unstarNameCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unstarNameCommand.equals(null));
+
+        // different names -> returns false
+        assertFalse(unstarNameCommand.equals(unstarIndexCommand));
+
+        // different index -> returns false
+        assertFalse(unstarIndexCommand.equals(unstarNameCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        // Testing with name
+        Name targetName = new Name("John Doe");
+        UnstarCommand unstarCommandByName = new UnstarCommand(targetName);
+        String expectedNameString = String.format("UnstarCommand[targetName=%s]", targetName);
+        assertEquals(expectedNameString, unstarCommandByName.toString());
+
+        // Testing with index
+        Index targetIndex = Index.fromOneBased(1);
+        UnstarCommand unstarCommandByIndex = new UnstarCommand(targetIndex);
+        String expectedIndexString = String.format("UnstarCommand[targetIndex=%d]", targetIndex.getOneBased());
+        assertEquals(expectedIndexString, unstarCommandByIndex.toString());
+    }
+
+    @Test
+    public void execute_personAlreadyUnstarred_throwsCommandException() {
+        Person personToUnstar = model.getFilteredPersonList().get(0);
+        Person alreadyUnstarredPerson = new Person(
+                personToUnstar.getName(),
+                personToUnstar.getPhone(),
+                personToUnstar.getEmail(),
+                personToUnstar.getAddress(),
+                personToUnstar.getAge(),
+                personToUnstar.getSex(),
+                personToUnstar.getAppointment(),
+                personToUnstar.getTags(),
+                new StarredStatus("false"));
+        model.setPerson(personToUnstar, alreadyUnstarredPerson);
+
+        UnstarCommand unstarCommand = new UnstarCommand(alreadyUnstarredPerson.getName());
+
+        assertCommandFailure(unstarCommand, model,
+                String.format(UnstarCommand.MESSAGE_ALREADY_UNSTARRED, alreadyUnstarredPerson.getName()));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UnstarCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnstarCommandTest.java
@@ -1,15 +1,5 @@
 package seedu.address.logic.commands;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.StarredStatus;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,6 +8,17 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StarredStatus;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for UnstarCommand.

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,6 +22,8 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.StarCommand;
+import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -90,6 +92,22 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " *") instanceof ListCommand);
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), ()
             -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
+    }
+
+    @Test
+    public void parseCommand_star() throws Exception {
+        Person person = new PersonBuilder().build();
+        StarCommand command = (StarCommand) parser.parseCommand(
+                StarCommand.COMMAND_WORD + " " + person.getName());
+        assertEquals(new StarCommand(person.getName()), command);
+    }
+
+    @Test
+    public void parseCommand_unstar() throws Exception {
+        Person person = new PersonBuilder().build();
+        UnstarCommand command = (UnstarCommand) parser.parseCommand(
+                UnstarCommand.COMMAND_WORD + " " + person.getName());
+        assertEquals(new UnstarCommand(person.getName()), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,7 +27,6 @@ import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.PersonIsStarredPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -25,6 +25,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonIsStarredPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -86,7 +87,9 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " *") instanceof ListCommand);
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), ()
+            -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/StarCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StarCommandParserTest.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.StarCommand;
+import seedu.address.model.person.Name;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+public class StarCommandParserTest {
+    private StarCommandParser parser = new StarCommandParser();
+
+    @Test
+    public void parse_validName_returnsStarCommand() {
+        String userInput = "Alex Yeoh";
+        StarCommand expectedCommand = new StarCommand(new Name(userInput));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validIndex_returnsStarCommand() {
+        String userInput = "1"; // Assuming 1 is a valid index
+        StarCommand expectedCommand = new StarCommand(Index.fromOneBased(1));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, StarCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidName_throwsParseException() {
+        // Assuming names cannot contain special characters, like '@'
+        assertParseFailure(parser, "John @ Doe",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, StarCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/StarCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StarCommandParserTest.java
@@ -1,13 +1,14 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.StarCommand;
-import seedu.address.model.person.Name;
-
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.StarCommand;
+import seedu.address.model.person.Name;
 
 public class StarCommandParserTest {
     private StarCommandParser parser = new StarCommandParser();

--- a/src/test/java/seedu/address/logic/parser/UnstarCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnstarCommandParserTest.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnstarCommand;
+import seedu.address.model.person.Name;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+public class UnstarCommandParserTest {
+    private UnstarCommandParser parser = new UnstarCommandParser();
+
+    @Test
+    public void parse_validName_returnsUnstarCommand() {
+        String userInput = "Alex Yeoh";
+        UnstarCommand expectedCommand = new UnstarCommand(new Name(userInput));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validIndex_returnsUnstarCommand() {
+        String userInput = "1"; // Assuming 1 is a valid index
+        UnstarCommand expectedCommand = new UnstarCommand(Index.fromOneBased(1));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnstarCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidName_throwsParseException() {
+        // Assuming names cannot contain special characters, like '@'
+        assertParseFailure(parser, "John @ Doe",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnstarCommand.MESSAGE_USAGE));
+    }
+}
+

--- a/src/test/java/seedu/address/logic/parser/UnstarCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnstarCommandParserTest.java
@@ -1,13 +1,14 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.UnstarCommand;
-import seedu.address.model.person.Name;
-
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnstarCommand;
+import seedu.address.model.person.Name;
 
 public class UnstarCommandParserTest {
     private UnstarCommandParser parser = new UnstarCommandParser();

--- a/src/test/java/seedu/address/model/person/PersonIsStarredPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonIsStarredPredicateTest.java
@@ -1,15 +1,10 @@
 package seedu.address.model.person;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.testutil.PersonBuilder;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 public class PersonIsStarredPredicateTest {
     @Test

--- a/src/test/java/seedu/address/model/person/PersonIsStarredPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonIsStarredPredicateTest.java
@@ -1,0 +1,40 @@
+package seedu.address.model.person;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.testutil.PersonBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PersonIsStarredPredicateTest {
+    @Test
+    public void equals() {
+        PersonIsStarredPredicate firstPredicate = new PersonIsStarredPredicate();
+        PersonIsStarredPredicate secondPredicate = new PersonIsStarredPredicate();
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        assertTrue(firstPredicate.equals(secondPredicate));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+    }
+
+    @Test
+    public void toStringMethod() {
+        PersonIsStarredPredicate predicate = new PersonIsStarredPredicate();
+
+        String expected = PersonIsStarredPredicate.class.getCanonicalName() + "{}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -111,7 +111,8 @@ public class PersonTest {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", age="
                 + ALICE.getAge() + ", sex=" + ALICE.getSex()
-                + ", appointments=" + ALICE.getAppointment() + ", tags=" + ALICE.getTags() + "}";
+                + ", appointments=" + ALICE.getAppointment() + ", tags=" + ALICE.getTags()
+                + ", starredStatus=" + ALICE.getStarredStatus() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/SexTest.java
+++ b/src/test/java/seedu/address/model/person/SexTest.java
@@ -28,7 +28,7 @@ public class SexTest {
         assertFalse(Sex.isValidSex("")); // empty string
         assertFalse(Sex.isValidSex(" ")); // spaces only
 
-        // valid addresses
+        // valid sexes
         assertTrue(Sex.isValidSex("Female"));
         assertTrue(Sex.isValidSex("Male"));
         assertTrue(Sex.isValidSex("Unknown gender"));

--- a/src/test/java/seedu/address/model/person/StarredStatusTest.java
+++ b/src/test/java/seedu/address/model/person/StarredStatusTest.java
@@ -1,0 +1,57 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class StarredStatusTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new StarredStatus(null));
+    }
+
+    @Test
+    public void constructor_invalidStarredStatus_throwsIllegalArgumentException() {
+        String invalidStarredStatus = "foo";
+        assertThrows(IllegalArgumentException.class, () -> new StarredStatus(invalidStarredStatus));
+    }
+
+    @Test
+    public void isValidStarredStatus() {
+        // null starred status
+        assertThrows(NullPointerException.class, () -> StarredStatus.isValidStarredStatus(null));
+
+        // invalid starred status
+        assertFalse(StarredStatus.isValidStarredStatus("")); // empty string
+        assertFalse(StarredStatus.isValidStarredStatus(" ")); // spaces only
+
+        // valid starred statuses
+        assertTrue(StarredStatus.isValidStarredStatus("true"));
+        assertTrue(StarredStatus.isValidStarredStatus("false"));
+    }
+
+    @Test
+    public void equals() {
+        StarredStatus starredStatus = new StarredStatus("true");
+
+        // same values -> returns true
+        assertTrue(starredStatus.equals(new StarredStatus("true")));
+
+        // same object -> returns true
+        assertTrue(starredStatus.equals(starredStatus));
+
+        // null -> returns false
+        assertFalse(starredStatus.equals(null));
+
+        // different types -> returns false
+        assertFalse(starredStatus.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(starredStatus.equals(new StarredStatus("false")));
+    }
+}
+
+

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Sex;
+import seedu.address.model.person.StarredStatus;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -29,6 +30,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_SEX = "Fem@le";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_APPOINTMENT = "99/99/9999 9999";
+    private static final String INVALID_STARRED_STATUS = "starred";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -42,6 +44,7 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
+    private static final String VALID_STARRED_STATUS = "false";
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -53,7 +56,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -61,7 +64,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -70,7 +73,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -78,7 +81,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -87,7 +90,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -95,7 +98,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -104,7 +107,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -112,7 +115,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -121,7 +124,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAge_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        INVALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                        INVALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = Age.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -129,7 +132,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAge_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                null, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Age.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -138,7 +141,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidSex_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_AGE, INVALID_SEX, VALID_APPOINTMENT, VALID_TAGS);
+                        VALID_AGE, INVALID_SEX, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = Sex.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -146,7 +149,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullSex_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_AGE, null, VALID_APPOINTMENT, VALID_TAGS);
+                VALID_AGE, null, VALID_APPOINTMENT, VALID_TAGS, VALID_STARRED_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Sex.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -157,7 +160,7 @@ public class JsonAdaptedPersonTest {
         invalidAppointments.add(new JsonAdaptedAppointment(INVALID_APPOINTMENT));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, VALID_AGE, VALID_SEX, invalidAppointments, VALID_TAGS);
+                        VALID_ADDRESS, VALID_AGE, VALID_SEX, invalidAppointments, VALID_TAGS, VALID_STARRED_STATUS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -167,7 +170,24 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, invalidTags);
+                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, invalidTags, VALID_STARRED_STATUS);
         assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidStarredStatus_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, INVALID_STARRED_STATUS);
+        String expectedMessage = StarredStatus.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullStarredStatus_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_AGE, VALID_SEX, VALID_APPOINTMENT, VALID_TAGS, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StarredStatus.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -11,6 +11,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Sex;
+import seedu.address.model.person.StarredStatus;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -25,6 +26,7 @@ public class PersonBuilder {
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_AGE = "24";
     public static final String DEFAULT_SEX = "Female";
+    public static final String DEFAULT_STARRED_STATUS = "false";
 
     private Name name;
     private Phone phone;
@@ -34,6 +36,7 @@ public class PersonBuilder {
     private Sex sex;
     private Set<Appointment> appointments;
     private Set<Tag> tags;
+    private StarredStatus starredStatus;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -47,6 +50,7 @@ public class PersonBuilder {
         sex = new Sex(DEFAULT_SEX);
         appointments = new HashSet<>();
         tags = new HashSet<>();
+        starredStatus = new StarredStatus(DEFAULT_STARRED_STATUS);
     }
 
     /**
@@ -61,6 +65,7 @@ public class PersonBuilder {
         sex = personToCopy.getSex();
         appointments = new HashSet<>(personToCopy.getAppointment());
         tags = new HashSet<>(personToCopy.getTags());
+        starredStatus = personToCopy.getStarredStatus();
     }
 
     /**
@@ -128,8 +133,16 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code StarredStatus} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withStarredStatus(String starredStatus) {
+        this.starredStatus = new StarredStatus(starredStatus);
+        return this;
+    }
+
     public Person build() {
-        return new Person(name, phone, email, address, age, sex, appointments, tags);
+        return new Person(name, phone, email, address, age, sex, appointments, tags, starredStatus);
     }
 
 }


### PR DESCRIPTION
closes #79 
Ready for review

### Description
Users can now star and unstar contacts using commands `star [index/name]` and `unstar [index/name]`. Users can view their list of starred contacts using command `list *`.

### Key Changes
- Add attribute StarredStatus to Person model
- Add StarCommand and UnstarCommand and their respective parsers
- Update ListCommand to allow listing of starred contacts
- Update & add tests
- Update features in user guide

### Potential Enhancement
- Use GUI to represent starred contact on PersonCard