### PR TITLE
Update JAR file name to reflect as MediContact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'MediContact.jar'
 }
 
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
**Description**
When creating previous JAR files, the downloaded file was name `addressbook.jar`. To better reflect our product, we have renamed it as `MediContact.jar`

fixes #107 