### PR TITLE
Update Sort Command: Fix Issue #123

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -372,7 +372,8 @@ and the person will not be deleted.
 
 ### Sorting list based on Appointment Dates : `sort`
 
-Sorts the persons in the address book on the basis of their appointment dates.
+Sorts the persons in the address book on the basis of their appointment dates. Any contacts without appointments will 
+remain sorted alphabetically at the end of the list.
 
 Format: `sort`
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -2,8 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-
 
 /**
  * Sorts the persons in the address book by their appointment dates.
@@ -11,16 +11,18 @@ import seedu.address.model.Model;
 public class SortCommand extends Command {
 
     public static final String COMMAND_WORD = "sort";
-    public static final String MESSAGE_SUCCESS = "Sorted persons by appointment dates.";
+    public static final String MESSAGE_SUCCESS = "Sorted list by appointment dates.";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Sorts persons by their appointment dates in ascending order.\n"
             + "Example: " + COMMAND_WORD;
-
+    public static final String NO_APPOINTMENT_FOUND = "No contacts with appointment dates found.";
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
-        model.sortFilteredPersons();
+        int noAppointment = model.sortFilteredPersons();
+        if (noAppointment == -1) {
+            throw new CommandException(NO_APPOINTMENT_FOUND);
+        }
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands.exceptions;
 
+import seedu.address.logic.commands.Command;
+
 /**
  * Represents an error which occurs during execution of a {@link Command}.
  */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -91,8 +91,10 @@ public interface Model {
 
     /**
      * Replaces person list with the specified person list
+     *
+     * @return
      */
-    void sortFilteredPersons();
+    int sortFilteredPersons();
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -139,11 +139,16 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void sortFilteredPersons() {
+    public int sortFilteredPersons() {
         logger.info("Sorting filtered person list by appointments.");
+        boolean hasAppointments = filteredPersons.stream()
+                .anyMatch(Person::hasAppointments);
+        if (!hasAppointments) {
+            return -1;
+        }
         addressBook.sortByAppointments();
         assert !filteredPersons.isEmpty() : "Filtered person list should not be empty after sorting.";
-
+        return 1;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -139,6 +139,9 @@ public class Person {
         return otherPerson != null
                 && otherPerson.getName().equals(getName());
     }
+    public boolean hasAppointments() {
+        return !appointments.isEmpty();
+    }
 
     /**
      * Retrieves the earliest appointment date among this person's appointments.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -160,7 +160,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void sortFilteredPersons() {
+        public int sortFilteredPersons() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -2,16 +2,20 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -52,9 +56,8 @@ public class SortCommandTest {
     }
 
     @Test
-    public void execute_noAppointment_success() {
+    public void execute_noAppointment_throwsCommandException() {
         SortCommand sortCommand = new SortCommand();
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
 
         // Remove appointments from all persons for testing the no-appointment scenario
         model.getFilteredPersonList().forEach(person -> {
@@ -62,13 +65,15 @@ public class SortCommandTest {
             model.setPerson(person, editedPerson);
         });
 
-        // Execute the sort command
-        assertCommandSuccess(sortCommand, model, expectedMessage, model);
+        // Verify that executing sort throws CommandException with NO_APPOINTMENT_FOUND message
+        CommandException exception = assertThrows(CommandException.class, () -> sortCommand.execute(model));
+        assertEquals(SortCommand.NO_APPOINTMENT_FOUND, exception.getMessage());
 
         // Verify that the list remains unchanged since there are no appointment dates to sort
         List<Person> personsAfterSort = model.getFilteredPersonList();
         assertUnchangedList(personsAfterSort);
     }
+
 
     /**
      * Asserts that the persons list is sorted by appointment date in ascending order.

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -4,13 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### Description

Update sort command with the following enhancements:

1. Throw an error `No contacts with appointments found.` when the list contains no contacts with appointments to be sorted
2. Update UG to have better description of sort command.

Example: Sort when no contact has appointments

<img width="1351" alt="Screenshot 2024-11-04 at 12 50 00 AM" src="https://github.com/user-attachments/assets/96910bb2-8c8e-4702-b215-2ba0ffa37494">

Example: Sort when contacts have appointments

<img width="1258" alt="Screenshot 2024-11-04 at 12 48 44 AM" src="https://github.com/user-attachments/assets/6b01491e-c2ea-4d59-953b-e9c13f3759bb">
