### PR TITLE
Update Delete Command: Error Handling Fix Issues #131 and #143

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -30,7 +30,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_PERSON_CANCELLED = "Delete action cancelled.";
     public static final String MESSAGE_PERSON_NOT_FOUND = "The person's name provided is invalid";
-    public static final String MESSAGE_INVALID_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_INDEX = "The person's index provided is invalid";
     public static final String MESSAGE_CONFIRMATION = "Are you sure you want to delete %1$s from your address book?\n"
             + "This action is IRREVERSIBLE.";
     private final Name targetName;

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -30,14 +30,17 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             Index index = ParserUtil.parseIndex(trimmedArgs);
             return new DeleteCommand(index);
         } catch (ParseException pe) {
-
-            try {
-                Name name = ParserUtil.parseName(trimmedArgs);
-                return new DeleteCommand(name);
-            } catch (ParseException pe2) {
-
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe2);
+            if (trimmedArgs.matches("[^\\d]*")) { // Checks if the input does not contain digits
+                try {
+                    Name name = ParserUtil.parseName(trimmedArgs);
+                    return new DeleteCommand(name);
+                } catch (ParseException pe2) {
+                    // If name parsing fails, throw the specific name-related error message
+                    throw new ParseException(pe2.getMessage(), pe2);
+                }
+            } else {
+                // If it's not a name and not a valid index, throw an invalid index message
+                throw new ParseException(ParserUtil.MESSAGE_INVALID_INDEX);
             }
         }
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -24,7 +24,7 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Index provided is not a non-zero positive integer";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -23,7 +23,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validIndex_returnsDeleteCommand() {
-        String userInput = "1"; // Assuming 1 is a valid index
+        String userInput = "1";
         DeleteCommand expectedCommand = new DeleteCommand(Index.fromOneBased(1));
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -36,8 +36,26 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidName_throwsParseException() {
-        // Assuming names cannot contain special characters, like '@'
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertParseFailure(parser, "John @ Doe", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        // Test with a negative index
+        assertParseFailure(parser, "-1",
+                ParserUtil.MESSAGE_INVALID_INDEX);
+
+        // Test with zero index
+        assertParseFailure(parser, "0",
+                ParserUtil.MESSAGE_INVALID_INDEX);
+
+    }
+
+    @Test
+    public void parse_edgeCaseName_returnsDeleteCommand() {
+        String userInput = "John Doe"; // Valid name case
+        DeleteCommand expectedCommand = new DeleteCommand(new Name(userInput));
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -37,7 +37,7 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidName_throwsParseException() {
         // Assuming names cannot contain special characters, like '@'
-        assertParseFailure(parser, "John @ Doe",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        assertParseFailure(parser, "John @ Doe", expectedMessage);
     }
 }


### PR DESCRIPTION
### Description

Updated the delete command to have more specific messages for error handling.

Example: In case of negative numbers or zero
<img width="1340" alt="Screenshot 2024-11-04 at 1 07 34 PM" src="https://github.com/user-attachments/assets/9a1b7b90-50dd-4878-a7fb-22e77931dea2">

Example: In case of invalid index

<img width="1353" alt="Screenshot 2024-11-04 at 2 49 40 AM" src="https://github.com/user-attachments/assets/8ec1ddcc-0e3f-4622-93bf-5e47b85652a8">

Example: In case of invalid name
<img width="1355" alt="Screenshot 2024-11-04 at 2 49 51 AM" src="https://github.com/user-attachments/assets/2c49d67c-8dec-4277-80c2-56b6ab03c182">
