### PR TITLE
Make command case-insensitive for consistency

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -71,7 +71,10 @@ Medicontact is a **desktop app for managing contacts, optimized for use via a  L
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
 * Command keywords are case insensitive
-  e.g. if the command `add n/John Doe`, is equal to `Add n/John Doe`.
+  e.g. the command `add n/John Doe`, is equal to `Add n/John Doe`.
+
+* Parameter `NAME` is case insensitive
+  e.g. the command `delete John Doe`, is equal to `delete john doe` or `delete JOHn DoE`.
 
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </box>
@@ -255,7 +258,7 @@ Format: `import FILENAME.json`
 - File **must** be a `json` file. Ensure that the extension `.json` follows the `FILENAME` 
 - File **must** be in the same folder as the application JAR file. 
 - File **must** be in the expected format of MediContact data (see [Expected format](#expected format) for more details). 
-- Patient information in the file **must** follow constraints of MediContact. E.g. name must contain only alphanumeric characters, phone number must be exactly 8 digits long (see [Summary of parameter constraints](#summary of parameter constraints) for more details).
+- Patient information in the file **must** follow constraints of MediContact. E.g. name must contain only alphanumeric characters, phone number must be exactly 8 digits long (see [Summary of parameter constraints](#summary of parameter constraints) for more details). No duplicate names are allowed in the addressbook (e.g. `John Doe` and `JOhN DoE` cannot be in the same addressbook).
 
 <box type="warning" seamless>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -93,8 +93,13 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS b/AGE s/SEX [ap/APPOINTMENT
 
 <box type="tip" seamless>
 
-**Remarks**: A person can have any number of tags (including 0). Duplicate tags will be ignored (e.g. if added contact includes paramters `t/patient t/patient` the contact will only include 1 `patient` tag). 
-</box>
+**Remarks**: 
+
+- Duplicate names are not permitted. Addressbook cannot contain two `John Doe` or a `Betsy Crowe` and a `betsy crowe`
+
+- A person can have any number of tags (including 0). Duplicate tags will be ignored (e.g. if added contact includes paramters `t/patient t/patient` the contact will only include 1 `patient` tag). 
+
+  </box>
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 b/40 s/Male`

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,7 +14,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person's index provided is invalid";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_NAME = "The person's name provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -141,7 +141,7 @@ public class DeleteCommand extends Command {
      */
     private Person findPersonByName(List<Person> lastShownList) throws CommandException {
         Optional<Person> personOptional = lastShownList.stream()
-                .filter(person -> person.getName().equals(targetName))
+                .filter(person -> person.getName().toString().equalsIgnoreCase(targetName.toString()))
                 .findFirst();
 
         if (personOptional.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -87,7 +87,7 @@ public class EditCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         Person personToEdit = lastShownList.stream()
-                .filter(person -> person.getName().equals(name))
+                .filter(person -> person.getName().toString().equalsIgnoreCase(name.toString()))
                 .findFirst()
                 .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NAME));
 

--- a/src/main/java/seedu/address/logic/commands/StarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StarCommand.java
@@ -68,7 +68,7 @@ public class StarCommand extends Command {
 
         if (targetName != null) {
             Optional<Person> personOptional = lastShownList.stream()
-                    .filter(person -> person.getName().equals(targetName))
+                    .filter(person -> person.getName().toString().equalsIgnoreCase(targetName.toString()))
                     .findFirst();
 
             if (personOptional.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/UnstarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnstarCommand.java
@@ -68,7 +68,7 @@ public class UnstarCommand extends Command {
 
         if (targetName != null) {
             Optional<Person> personOptional = lastShownList.stream()
-                    .filter(person -> person.getName().equals(targetName))
+                    .filter(person -> person.getName().toString().equalsIgnoreCase(targetName.toString()))
                     .findFirst();
 
             if (personOptional.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -82,7 +82,7 @@ public class ViewCommand extends Command {
      */
     private Person findPersonByName(List<Person> personList) throws CommandException {
         Optional<Person> personOptional = personList.stream()
-                .filter(person -> person.getName().equals(fullName))
+                .filter(person -> person.getName().toString().equalsIgnoreCase(fullName.toString()))
                 .findFirst();
 
         if (personOptional.isEmpty()) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -136,8 +136,11 @@ public class Person {
             return true;
         }
 
+        String otherPersonName = otherPerson.getName().toString();
+        String thisPersonName = this.getName().toString();
+
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPersonName.equalsIgnoreCase(thisPersonName);
     }
     public boolean hasAppointments() {
         return !appointments.isEmpty();

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -136,11 +136,10 @@ public class Person {
             return true;
         }
 
-        String otherPersonName = otherPerson.getName().toString();
         String thisPersonName = this.getName().toString();
 
         return otherPerson != null
-                && otherPersonName.equalsIgnoreCase(thisPersonName);
+                && otherPerson.getName().toString().equalsIgnoreCase(thisPersonName);
     }
     public boolean hasAppointments() {
         return !appointments.isEmpty();

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -42,7 +42,8 @@ public class UniquePersonList implements Iterable<Person> {
      */
     public boolean containsName(Name toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(person -> person.getName().equals(toCheck));
+        return internalList.stream().anyMatch(
+                person -> person.getName().toString().equalsIgnoreCase(toCheck.toString()));
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -46,9 +46,9 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";


### PR DESCRIPTION
Fix #133 

### Description
Make Delete, Edit, Star, Unstar and View case insensitive. E.g. `delete John Doe` is now equivalent to `delete JOhN DoE`

### Key Changes
- Modify `isSamePerson` so that duplicate handling is case insensitive. Users cannot add `evie sage` and `Evie Sage` to the same address book. 
- Modify how commands find by name such that it is case insensitive