### PR TITLE
Fix pe bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -23,7 +23,7 @@ Medicontact is a desktop app to help **small GP Clinics in Singapore for manage 
 
    <img src="images/quickStart.png" width="800"/>
 
-1. Open a command terminal (called `Terminal` on MacOS and `Command Prompt` on Windows). Change directory into the folder you put the jar file in using the command `cd`. For example, if you created your home folder `MediContact` in your Desktop type `cd Desktop/MediContact`. If you created your home folder `MediContact` in Documents, type `cd Documents/MediContact`. If you named your home folder some other FILENAME, replace `MediContact` with filename. 
+1. Open a command terminal (called `Terminal` on MacOS and `Command Prompt` on Windows). Change directory into the folder you put the jar file in using the command `cd`. Here are detailed instructions for how to change directory in [MacOS](https://youtu.be/VRFcEMPES7U) and in [Windows](https://www.youtube.com/watch?v=BfXh11ryBJg).
 
 1. Once you're in the same directory as `MediContact.jar`, use the command `java -jar MediContact.jar` to run the application. You're terminal should look something like this right before you enter the last command. The redacted portion should show your current directory.
 

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -79,7 +79,8 @@ public class NoteCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_NOTE_SUCCESS, personToEdit.getName(), editedPerson.getNote().toString()));
+        return new CommandResult(String.format(
+                MESSAGE_EDIT_NOTE_SUCCESS, personToEdit.getName(), editedPerson.getNote().toString()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -71,7 +71,7 @@ public class NoteCommand extends Command {
         }
 
         Person personToEdit = lastShownList.stream()
-                .filter(person -> person.getName().equals(name))
+                .filter(person -> person.getName().toString().equalsIgnoreCase(name.toString()))
                 .findFirst()
                 .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NAME));
 
@@ -79,7 +79,7 @@ public class NoteCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_NOTE_SUCCESS, name, editedPerson.getNote().toString()));
+        return new CommandResult(String.format(MESSAGE_EDIT_NOTE_SUCCESS, personToEdit.getName(), editedPerson.getNote().toString()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/UnstarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnstarCommand.java
@@ -37,8 +37,6 @@ public class UnstarCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_UNSTAR_PERSON_SUCCESS = "Unstarred Person: %1$s";
-    public static final String MESSAGE_PERSON_NOT_FOUND = "The person's name provided is invalid";
-    public static final String MESSAGE_INVALID_INDEX = "The person's index provided is invalid";
     public static final String MESSAGE_ALREADY_UNSTARRED = "%1$s is not starred";
 
     private final Name targetName;

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -3,9 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
@@ -40,7 +41,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                 }
             } else {
                 // If it's not a name and not a valid index, throw an invalid index message
-                throw new ParseException(ParserUtil.MESSAGE_INVALID_INDEX);
+                throw new ParseException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 
@@ -26,23 +27,19 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
-
-        try {
+        if (isNumber(trimmedArgs)) {
             Index index = ParserUtil.parseIndex(trimmedArgs);
             return new DeleteCommand(index);
-        } catch (ParseException pe) {
-            if (trimmedArgs.matches("[^\\d]*")) { // Checks if the input does not contain digits
-                try {
-                    Name name = ParserUtil.parseName(trimmedArgs);
-                    return new DeleteCommand(name);
-                } catch (ParseException pe2) {
-                    // If name parsing fails, throw the specific name-related error message
-                    throw new ParseException(pe2.getMessage(), pe2);
-                }
-            } else {
-                // If it's not a name and not a valid index, throw an invalid index message
-                throw new ParseException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-            }
         }
+
+        if (Name.isValidName(trimmedArgs)) {
+            Name name = ParserUtil.parseName(trimmedArgs);
+            return new DeleteCommand(name);
+        }
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    private boolean isNumber(String index) {
+        return index.matches("-?\\d+");
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.Messages;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.note.Note;
@@ -24,8 +25,6 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index provided is not a non-zero positive integer";
-
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -34,7 +33,7 @@ public class ParserUtil {
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }

--- a/src/main/java/seedu/address/logic/parser/StarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StarCommandParser.java
@@ -1,11 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.StarCommand;
-import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 

--- a/src/main/java/seedu/address/logic/parser/StarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StarCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDE
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.StarCommand;
+import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 
@@ -26,23 +27,20 @@ public class StarCommandParser implements Parser<StarCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, StarCommand.MESSAGE_USAGE));
         }
 
-
-        try {
+        if (isNumber(trimmedArgs)) {
             Index index = ParserUtil.parseIndex(trimmedArgs);
             return new StarCommand(index);
-        } catch (ParseException pe) {
-
-            if (trimmedArgs.matches("[^\\d]*")) {
-                try {
-                    Name name = ParserUtil.parseName(trimmedArgs);
-                    return new StarCommand(name);
-                } catch (ParseException pe2) {
-                    throw new ParseException(pe2.getMessage(), pe2);
-                }
-            } else {
-                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-            }
         }
+
+        if (Name.isValidName(trimmedArgs)) {
+            Name name = ParserUtil.parseName(trimmedArgs);
+            return new StarCommand(name);
+        }
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StarCommand.MESSAGE_USAGE));
+    }
+
+    private boolean isNumber(String index) {
+        return index.matches("-?\\d+");
     }
 }
 

--- a/src/main/java/seedu/address/logic/parser/StarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StarCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.StarCommand;
@@ -39,7 +40,7 @@ public class StarCommandParser implements Parser<StarCommand> {
                     throw new ParseException(pe2.getMessage(), pe2);
                 }
             } else {
-                throw new ParseException(ParserUtil.MESSAGE_INVALID_INDEX);
+                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
     }

--- a/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDE
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnstarCommand;
+import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 
@@ -26,23 +27,20 @@ public class UnstarCommandParser implements Parser<UnstarCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnstarCommand.MESSAGE_USAGE));
         }
 
-
-        try {
+        if (isNumber(trimmedArgs)) {
             Index index = ParserUtil.parseIndex(trimmedArgs);
             return new UnstarCommand(index);
-        } catch (ParseException pe) {
-
-            if (trimmedArgs.matches("[^\\d]*")) {
-                try {
-                    Name name = ParserUtil.parseName(trimmedArgs);
-                    return new UnstarCommand(name);
-                } catch (ParseException pe2) {
-                    throw new ParseException(pe2.getMessage(), pe2);
-                }
-            } else {
-                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-            }
         }
+
+        if (Name.isValidName(trimmedArgs)) {
+            Name name = ParserUtil.parseName(trimmedArgs);
+            return new UnstarCommand(name);
+        }
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnstarCommand.MESSAGE_USAGE));
+    }
+
+    private boolean isNumber(String index) {
+        return index.matches("-?\\d+");
     }
 }
 

--- a/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnstarCommand;
@@ -39,7 +40,7 @@ public class UnstarCommandParser implements Parser<UnstarCommand> {
                     throw new ParseException(pe2.getMessage(), pe2);
                 }
             } else {
-                throw new ParseException(ParserUtil.MESSAGE_INVALID_INDEX);
+                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
     }

--- a/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnstarCommandParser.java
@@ -1,11 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnstarCommand;
-import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 

--- a/src/main/java/seedu/address/model/person/Sex.java
+++ b/src/main/java/seedu/address/model/person/Sex.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Sex {
 
-    public static final String MESSAGE_CONSTRAINTS = "Names should only contain alphanumeric characters and spaces, "
+    public static final String MESSAGE_CONSTRAINTS = "Sex should only contain alphanumeric characters and spaces, "
             + "and it should not be blank";
 
     /*

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.model.person.Name;
 
@@ -36,7 +37,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidName_throwsParseException() {
-        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE);
         assertParseFailure(parser, "John @ Doe", expectedMessage);
     }
 
@@ -44,11 +45,11 @@ public class DeleteCommandParserTest {
     public void parse_invalidIndex_throwsParseException() {
         // Test with a negative index
         assertParseFailure(parser, "-1",
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // Test with zero index
         assertParseFailure(parser, "0",
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -13,6 +12,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Address;
@@ -57,7 +57,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+        assertThrows(ParseException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, ()
             -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 

--- a/src/test/java/seedu/address/logic/parser/StarCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StarCommandParserTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.StarCommand;
 import seedu.address.model.person.Name;
 

--- a/src/test/java/seedu/address/logic/parser/StarCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StarCommandParserTest.java
@@ -7,6 +7,8 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.StarCommand;
 import seedu.address.model.person.Name;
 
@@ -37,18 +39,18 @@ public class StarCommandParserTest {
     public void parse_invalidName_throwsParseException() {
         // Assuming names cannot contain special characters, like '@'
         assertParseFailure(parser, "John @ Doe",
-                Name.MESSAGE_CONSTRAINTS);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, StarCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidIndex_throwsParseException() {
         // Test with a negative index
         assertParseFailure(parser, "-1",
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // Test with zero index
         assertParseFailure(parser, "0",
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UnstarCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnstarCommandParserTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.model.person.Name;
 

--- a/src/test/java/seedu/address/logic/parser/UnstarCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnstarCommandParserTest.java
@@ -7,6 +7,8 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.UnstarCommand;
 import seedu.address.model.person.Name;
 
@@ -37,18 +39,18 @@ public class UnstarCommandParserTest {
     public void parse_invalidName_throwsParseException() {
         // Assuming names cannot contain special characters, like '@'
         assertParseFailure(parser, "John @ Doe",
-                Name.MESSAGE_CONSTRAINTS);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnstarCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidIndex_throwsParseException() {
         // Test with a negative index
         assertParseFailure(parser, "-1",
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // Test with zero index
         assertParseFailure(parser, "0",
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -3,11 +3,11 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.model.person.Name;
 
@@ -41,7 +41,7 @@ public class ViewCommandParserTest {
     public void parse_invalidIndex_throwsParseException() {
         // index
         String userInput = "-1";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, userInput, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test


### PR DESCRIPTION
Closes #203 
When `sex` field is empty, error message says `Names` field has the error. This goes against the expected behaviour. Fixed the typo in error message. 

Closes #213 
Update UG to have correct instructions for changing directory in `Quick Start`

Closes #215 
When there is overflow for `command INDEX` the error message gives the following error message: 
![Screenshot 2024-11-10 at 2 15 31 PM](https://github.com/user-attachments/assets/db23fdd1-e176-43f2-ae0b-c1bb3046c507)
This is incorrect behaviour as the index provided is in fact a non-zero positive integer. Fixed to fulfill the expected behaviour:
![Screenshot 2024-11-10 at 2 16 48 PM](https://github.com/user-attachments/assets/4c087f75-1924-4d7c-b2d4-7b1b3665e759)
 
Closes #256
User guide states that for all features, the parameter NAME should be case insensitive. For all commands the parameter is case insensitive except for  `note`.
![Screenshot 2024-11-10 at 2 18 14 PM](https://github.com/user-attachments/assets/1c7e90bd-f57f-4df3-bc88-6a2c9262deb9)
Fixed NAME to be case insensitive for `note` as well. 

Closes #257
When an index is in the name `e.g. Evie S8ge` the commands `delete`, `star` and `unstar` do not function for `command NAME`. Fixed this functionality. 
